### PR TITLE
Logs and brokers

### DIFF
--- a/lib/Genesis.js
+++ b/lib/Genesis.js
@@ -124,10 +124,14 @@ function genesis(__options = {}) {
 				async function retrieveModules(modules) {
 					modules = JSON.parse(JSON.stringify(modules));
 					const xgrls = [];
+					const modulesByxgrl = {};
+					
 					for (const moduleName in modules) {
 						const xgrl = Config.Sources[modules[moduleName].Source];
 						if (xgrls.indexOf(xgrl) === -1) xgrls.push(xgrl);
 						modules[moduleName].Source = xgrl
+						if (!(xgrl in modulesByxgrl)) modulesByxgrl[xgrl]=[moduleName];
+						else modulesByxgrl[xgrl].push(moduleName);
 					}
 					// console.dir(xgrls);
 
@@ -149,17 +153,18 @@ function genesis(__options = {}) {
 							}
 
 							const modulePromises = [];
-							for (const moduleName in modules) {
-								if (modules[moduleName].Source === xgrl) {
+							//for (const moduleName in modules) {
+							//	if (modules[moduleName].Source === xgrl) {
+							for (const moduleName of modulesByxgrl[xgrl]){
 									// console.log(`${moduleName} => ${xgrl}`);
-									modulePromises.push(new Promise(async (res) => {
-										ModCache[moduleName] = await broker.getModule({
-											Module: moduleName,
-											Version: modules[moduleName].Version || undefined
-										});
-										res();
-									}))
-								}
+								modulePromises.push(new Promise(async (res) => {
+									ModCache[moduleName] = await broker.getModule({
+										Module: moduleName,
+										Version: modules[moduleName].Version || undefined
+									});
+									res();
+								}));
+							//	}
 							}
 							await Promise.all(modulePromises);
 							res();

--- a/lib/Genesis.js
+++ b/lib/Genesis.js
@@ -153,10 +153,9 @@ function genesis(__options = {}) {
 							}
 
 							const modulePromises = [];
-							//for (const moduleName in modules) {
-							//	if (modules[moduleName].Source === xgrl) {
+						
 							for (const moduleName of modulesByxgrl[xgrl]){
-									// console.log(`${moduleName} => ${xgrl}`);
+								// console.log(`${moduleName} => ${xgrl}`);
 								modulePromises.push(new Promise(async (res) => {
 									ModCache[moduleName] = await broker.getModule({
 										Module: moduleName,
@@ -164,9 +163,11 @@ function genesis(__options = {}) {
 									});
 									res();
 								}));
-							//	}
 							}
 							await Promise.all(modulePromises);
+							
+							//All brokers are stopped during Genesis compile stop
+							
 							res();
 						}))
 					}

--- a/lib/Genesis.js
+++ b/lib/Genesis.js
@@ -687,7 +687,7 @@ function genesis(__options = {}) {
 				for (let folder in ModCache) {
 					ModulePromiseArray.push(new Promise(async (res) => {
 						await cacheInterface.addModule(folder, ModCache[folder]).catch((error) => {
-							log.e(`Failed to find module ${ModCache[folder]} at `)
+							log.e(`Failed to find module ${ModCache[folder]} at ${CacheDir}`);
 						});
 						log.v(`Finished installing dependencies for ${folder}`);
 						res();

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -116,8 +116,8 @@ class Broker {
 		});
 
 		if (response.err) 
-			throw new Error(`Module ${moduleDefinition.Module} not returned ${
-				}from ${this.xgrl}\n${response.err}`);
+			throw new Error(`Module ${moduleDefinition.Module} not returned${ '
+				'}from ${this.xgrl}\n${response.err}`);
 
 		//console.log(`${response.cmd.Name} => ${response.cmd.Module.length}`);
 		return response.cmd.Module;

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -85,6 +85,7 @@ class Broker {
 		// show its tree
 		// log.v(tree.sync(cachePath, '**/*'));
 
+		log.d('Start the Broker subsystem');
 		this.system = new Nexus({
 			cache: cachePath,
 			silent: true,

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -14,7 +14,7 @@ class Broker {
 	constructor(xgrl, __options = {}) {
 		log = (('logger' in __options) && (__options['logger'])) ? 
 			__options.logger : createLogger(__options);
-		log.v(`Construct Broker instance for ${xgrl}`);
+		log.v(`Constructing Broker for ${xgrl}`);
 		this.configOptions = __options;
 		this.xgrl = xgrl;
 		this.debug = __options.debug || false;
@@ -55,7 +55,7 @@ class Broker {
 		// show its tree
 		// log.v(tree.sync(cachePath, '**/*'));
 
-		log.v(`Start Broker xgraph for ${xgrl}`);
+		log.v(`Starting Broker subsystem for ${xgrl}`);
 		this.system = new Nexus({
 			cache: cachePath,
 			silent: true,

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -55,7 +55,7 @@ class Broker {
 		// show its tree
 		// log.v(tree.sync(cachePath, '**/*'));
 
-		log.v(`Starting broker subsystem for Source ${xgrl}`);
+		log.v(`Starting broker for Source ${xgrl}`);
 		this.system = new Nexus({
 			cache: cachePath,
 			silent: true,

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -116,8 +116,7 @@ class Broker {
 		});
 
 		if (response.err) 
-			throw new Error(`Module ${moduleDefinition.Module} not returned${ '
-				'}from ${this.xgrl}\n${response.err}`);
+			throw new Error(`Module ${moduleDefinition.Module} not returned from ${this.xgrl}\n${response.err}`);
 
 		//console.log(`${response.cmd.Name} => ${response.cmd.Module.length}`);
 		return response.cmd.Module;

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -85,7 +85,7 @@ class Broker {
 		// show its tree
 		// log.v(tree.sync(cachePath, '**/*'));
 
-		log.d('Start the Broker subsystem');
+		log.d(`Start Broker xgraph for ${xgrl}`);
 		this.system = new Nexus({
 			cache: cachePath,
 			silent: true,
@@ -93,9 +93,6 @@ class Broker {
 		});
 
 		this.hooks = await this.system.boot();
-
-
-
 	}
 
 	async getModule(moduleDefinition) {

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -14,7 +14,7 @@ class Broker {
 	constructor(xgrl, __options = {}) {
 		log = (('logger' in __options) && (__options['logger'])) ? 
 			__options.logger : createLogger(__options);
-		log.d(`Construct Broker instance for ${xgrl}`);
+		log.v(`Construct Broker instance for ${xgrl}`);
 		this.configOptions = __options;
 		this.xgrl = xgrl;
 		this.debug = __options.debug || false;
@@ -55,7 +55,7 @@ class Broker {
 		// show its tree
 		// log.v(tree.sync(cachePath, '**/*'));
 
-		log.d(`Start Broker xgraph for ${xgrl}`);
+		log.v(`Start Broker xgraph for ${xgrl}`);
 		this.system = new Nexus({
 			cache: cachePath,
 			silent: true,

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -115,10 +115,12 @@ class Broker {
 			});
 		});
 
-		if (response.err) throw new Error("Module not returned");
+		if (response.err) 
+			throw new Error(`Module ${moduleDefinition.Module} not returned 
+				from ${this.xgrl}\n${response.err}`);
 
-		console.log(`${response.cmd.Name} => ${response.cmd.Module.length}`);
-		return response.cmd.Module
+		//console.log(`${response.cmd.Name} => ${response.cmd.Module.length}`);
+		return response.cmd.Module;
 
 		// console.dir(response);
 	}

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -44,6 +44,7 @@ let configOptions;
 
 class Broker {
 	constructor(xgrl, __options = {}) {
+		log.d(`Construct Broker instance for ${xgrl}`);
 		this.configOptions = __options;
 		this.xgrl = xgrl;
 		this.debug = __options.debug || false;

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -1,49 +1,19 @@
 #!/usr/bin/env node
 
 
-const log = new (require('signale').Signale)({
-	disabled: false,
-	interactive: false,
-	stream: process.stdout,
-	types: {
-		v: {
-			badge: '',
-			color: 'grey',
-			label: 'verbose'
-		},
-		d: {
-			badge: '',
-			color: 'magenta',
-			label: 'debug'
-		},
-		i: {
-			badge: '',
-			color: 'cyan',
-			label: 'info'
-		},
-		w: {
-			badge: '',
-			color: 'yellow',
-			label: 'warning'
-		},
-		e: {
-			badge: '',
-			color: 'red',
-			label: 'error'
-		}
-	}
-});
-
+const createLogger = require('./Logger.js');
 const CacheInterface = require('./Cache.js');
 const Nexus = require('./Nexus.js');
 const tmp = require('tmp-promise');
 const path = require('path');
 const { getProtocolObject } = require('./xgrl.js');
-let configOptions;
+let configOptions, log;
 
 
 class Broker {
 	constructor(xgrl, __options = {}) {
+		log = (('logger' in __options) && (__options['logger'])) ? 
+			__options.logger : createLogger(__options);
 		log.d(`Construct Broker instance for ${xgrl}`);
 		this.configOptions = __options;
 		this.xgrl = xgrl;

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -55,7 +55,7 @@ class Broker {
 		// show its tree
 		// log.v(tree.sync(cachePath, '**/*'));
 
-		log.v(`Starting broker for Source ${xgrl}`);
+		log.i(`Starting broker for Source ${xgrl}`);
 		this.system = new Nexus({
 			cache: cachePath,
 			silent: true,

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -116,8 +116,8 @@ class Broker {
 		});
 
 		if (response.err) 
-			throw new Error(`Module ${moduleDefinition.Module} not returned 
-				from ${this.xgrl}\n${response.err}`);
+			throw new Error(`Module ${moduleDefinition.Module} not returned ${
+				}from ${this.xgrl}\n${response.err}`);
 
 		//console.log(`${response.cmd.Name} => ${response.cmd.Module.length}`);
 		return response.cmd.Module;

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -14,7 +14,7 @@ class Broker {
 	constructor(xgrl, __options = {}) {
 		log = (('logger' in __options) && (__options['logger'])) ? 
 			__options.logger : createLogger(__options);
-		log.v(`Constructing Broker for ${xgrl}`);
+		log.v(`Constructing broker for Source ${xgrl}`);
 		this.configOptions = __options;
 		this.xgrl = xgrl;
 		this.debug = __options.debug || false;
@@ -55,7 +55,7 @@ class Broker {
 		// show its tree
 		// log.v(tree.sync(cachePath, '**/*'));
 
-		log.v(`Starting Broker subsystem for ${xgrl}`);
+		log.v(`Starting broker subsystem for Source ${xgrl}`);
 		this.system = new Nexus({
 			cache: cachePath,
 			silent: true,

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -1,6 +1,39 @@
 #!/usr/bin/env node
 
-const createLogger = require('../lib/Logger.js');
+
+const log = new (require('signale').Signale)({
+	disabled: false,
+	interactive: false,
+	stream: process.stdout,
+	types: {
+		v: {
+			badge: '',
+			color: 'grey',
+			label: 'verbose'
+		},
+		d: {
+			badge: '',
+			color: 'magenta',
+			label: 'debug'
+		},
+		i: {
+			badge: '',
+			color: 'cyan',
+			label: 'info'
+		},
+		w: {
+			badge: '',
+			color: 'yellow',
+			label: 'warning'
+		},
+		e: {
+			badge: '',
+			color: 'red',
+			label: 'error'
+		}
+	}
+});
+
 const CacheInterface = require('./Cache.js');
 const Nexus = require('./Nexus.js');
 const tmp = require('tmp-promise');

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -26,7 +26,7 @@ class Broker {
 		const tmpDir = await tmp.dir();
 		const dir = tmpDir.path;
 		this.tmpCleanup = tmpDir.cleanup;
-		const protocolObject = await getProtocolObject(xgrl);
+		const protocolObject = await getProtocolObject(xgrl, this.configOptions);
 
 		const cachePath = path.join(dir, 'cache');
 		this.proxyPid = '0'.repeat(32);

--- a/lib/broker.js
+++ b/lib/broker.js
@@ -115,7 +115,9 @@ class Broker {
 			});
 		});
 
-		// console.log(`${response.cmd.Name} => ${response.cmd.Module.length}`);
+		if (response.err) throw new Error("Module not returned");
+
+		console.log(`${response.cmd.Name} => ${response.cmd.Module.length}`);
 		return response.cmd.Module
 
 		// console.dir(response);

--- a/lib/xgrl.js
+++ b/lib/xgrl.js
@@ -46,6 +46,7 @@ module.exports = {
 
 
 async function getProtocolObject(xgrl) {
+	log.d(`Get Protocol object ${xgrl}`);
 	let protocol = xgrl.split(/:\/\//)[0];
 	let _domain = xgrl.split(/:\/\//)[1];
 

--- a/lib/xgrl.js
+++ b/lib/xgrl.js
@@ -16,7 +16,7 @@ module.exports = {
 async function getProtocolObject(xgrl, __options) {
 	const log = (('logger' in __options) && (__options['logger'])) ? 
 		__options.logger : createLogger(__options);
-	log.v(`Get Protocol object ${xgrl}`);
+	log.v(`Getting protocol ${xgrl}`);
 	let protocol = xgrl.split(/:\/\//)[0];
 	let _domain = xgrl.split(/:\/\//)[1];
 
@@ -70,7 +70,7 @@ function getProtocolModule(protocol, __options) {
 	return new Promise(function (resolve, reject) {
 		let cacheFilepath = path.join(appdata, protocol);
 		if (fs.existsSync(cacheFilepath)) {
-			log.v(`Return ${protocol} from ${cacheFilepath}`);
+			log.v(`Returning ${protocol} from ${cacheFilepath}`);
 			return resolve(JSON.parse(fs.readFileSync(cacheFilepath).toString()));
 		}
 
@@ -92,7 +92,7 @@ function getProtocolModule(protocol, __options) {
 			});
 			res.on('end', _ => {
 				try {
-					log.v(`Return ${protocol} from protocols.xgraphdev.com`);
+					log.v(`Returning ${protocol} from protocols.xgraphdev.com`);
 					resolve(JSON.parse(response));
 					try { fs.writeFileSync(cacheFilepath, response); } catch (e) {
 						reject({

--- a/lib/xgrl.js
+++ b/lib/xgrl.js
@@ -82,7 +82,7 @@ function getProtocolModule(protocol, __options) {
 			rejectUnauthorized: false,
 		};
 		
-		log.v(`Trying: ${protocol} from protocols.xgraphdev.com`);
+		log.v(`Retrieving: ${protocol} from protocols.xgraphdev.com`);
 
 		let req = https.request(options, function (res) {
 			res.setEncoding('utf8');

--- a/lib/xgrl.js
+++ b/lib/xgrl.js
@@ -98,7 +98,7 @@ function getProtocolModule(protocol) {
 	return new Promise(function (resolve, reject) {
 		let cacheFilepath = path.join(appdata, protocol);
 		if (fs.existsSync(cacheFilepath)) {
-			log.d(`Get protocol ${protocol} from ${cacheFilepath}`);
+			log.d(`Return ${protocol} from ${cacheFilepath}`);
 			return resolve(JSON.parse(fs.readFileSync(cacheFilepath).toString()));
 		}
 
@@ -110,7 +110,7 @@ function getProtocolModule(protocol) {
 			rejectUnauthorized: false,
 		};
 		
-		log.d(`Get protocol ${protocol} from protocols.xgraphdev.com`);
+		log.d(`${protocol} from protocols.xgraphdev.com`);
 
 		let req = https.request(options, function (res) {
 			res.setEncoding('utf8');

--- a/lib/xgrl.js
+++ b/lib/xgrl.js
@@ -98,6 +98,7 @@ function getProtocolModule(protocol) {
 	return new Promise(function (resolve, reject) {
 		let cacheFilepath = path.join(appdata, protocol);
 		if (fs.existsSync(cacheFilepath)) {
+			log.d(`Get protocol ${protocol} from ${cacheFilepath}`);
 			return resolve(JSON.parse(fs.readFileSync(cacheFilepath).toString()));
 		}
 

--- a/lib/xgrl.js
+++ b/lib/xgrl.js
@@ -1,40 +1,8 @@
 
-
-const log = new (require('signale').Signale)({
-	disabled: false,
-	interactive: false,
-	stream: process.stdout,
-	types: {
-		v: {
-			badge: '',
-			color: 'grey',
-			label: 'verbose'
-		},
-		d: {
-			badge: '',
-			color: 'magenta',
-			label: 'debug'
-		},
-		i: {
-			badge: '',
-			color: 'cyan',
-			label: 'info'
-		},
-		w: {
-			badge: '',
-			color: 'yellow',
-			label: 'warning'
-		},
-		e: {
-			badge: '',
-			color: 'red',
-			label: 'error'
-		}
-	}
-});
 const fs = require('fs');
 const path = require('path');
 const https = require('https');
+const createLogger = require('./Logger.js');
 const appdata = path.join((process.env.APPDATA || path.join(process.env.HOME,
 	(process.platform == 'darwin' ? 'Library/Preferences' : ''))), '.xgraph');
 try { fs.mkdirSync(appdata); } catch (e) { ''; }
@@ -45,7 +13,9 @@ module.exports = {
 };
 
 
-async function getProtocolObject(xgrl) {
+async function getProtocolObject(xgrl, __options) {
+	const log = (('logger' in __options) && (__options['logger'])) ? 
+		__options.logger : createLogger(__options);
 	log.d(`Get Protocol object ${xgrl}`);
 	let protocol = xgrl.split(/:\/\//)[0];
 	let _domain = xgrl.split(/:\/\//)[1];
@@ -55,7 +25,7 @@ async function getProtocolObject(xgrl) {
 		protocol = 'fs';
 	}
 
-	let protocolObject = await getProtocolModule(protocol);
+	let protocolObject = await getProtocolModule(protocol, __options);
 
 	//need to rebuild the par from the argsArr
 
@@ -94,7 +64,9 @@ async function getProtocolObject(xgrl) {
 /**
 * load protocol to access modules
 */
-function getProtocolModule(protocol) {
+function getProtocolModule(protocol, __options) {
+	const log = (('logger' in __options) && (__options['logger'])) ? 
+			__options.logger : createLogger(__options);
 	return new Promise(function (resolve, reject) {
 		let cacheFilepath = path.join(appdata, protocol);
 		if (fs.existsSync(cacheFilepath)) {

--- a/lib/xgrl.js
+++ b/lib/xgrl.js
@@ -16,7 +16,7 @@ module.exports = {
 async function getProtocolObject(xgrl, __options) {
 	const log = (('logger' in __options) && (__options['logger'])) ? 
 		__options.logger : createLogger(__options);
-	log.d(`Get Protocol object ${xgrl}`);
+	log.v(`Get Protocol object ${xgrl}`);
 	let protocol = xgrl.split(/:\/\//)[0];
 	let _domain = xgrl.split(/:\/\//)[1];
 
@@ -70,7 +70,7 @@ function getProtocolModule(protocol, __options) {
 	return new Promise(function (resolve, reject) {
 		let cacheFilepath = path.join(appdata, protocol);
 		if (fs.existsSync(cacheFilepath)) {
-			log.d(`Return ${protocol} from ${cacheFilepath}`);
+			log.v(`Return ${protocol} from ${cacheFilepath}`);
 			return resolve(JSON.parse(fs.readFileSync(cacheFilepath).toString()));
 		}
 
@@ -82,7 +82,7 @@ function getProtocolModule(protocol, __options) {
 			rejectUnauthorized: false,
 		};
 		
-		log.d(`${protocol} from protocols.xgraphdev.com`);
+		log.v(`Trying: ${protocol} from protocols.xgraphdev.com`);
 
 		let req = https.request(options, function (res) {
 			res.setEncoding('utf8');
@@ -92,6 +92,7 @@ function getProtocolModule(protocol, __options) {
 			});
 			res.on('end', _ => {
 				try {
+					log.v(`Return ${protocol} from protocols.xgraphdev.com`);
 					resolve(JSON.parse(response));
 					try { fs.writeFileSync(cacheFilepath, response); } catch (e) {
 						reject({

--- a/lib/xgrl.js
+++ b/lib/xgrl.js
@@ -107,6 +107,8 @@ function getProtocolModule(protocol) {
 			method: 'GET',
 			rejectUnauthorized: false,
 		};
+		
+		log.d(`Get protocol ${protocol} from protocols.xgraphdev.com`);
 
 		let req = https.request(options, function (res) {
 			res.setEncoding('utf8');

--- a/lib/xgrl.js
+++ b/lib/xgrl.js
@@ -16,7 +16,7 @@ module.exports = {
 async function getProtocolObject(xgrl, __options) {
 	const log = (('logger' in __options) && (__options['logger'])) ? 
 		__options.logger : createLogger(__options);
-	log.v(`Getting protocol ${xgrl}`);
+	
 	let protocol = xgrl.split(/:\/\//)[0];
 	let _domain = xgrl.split(/:\/\//)[1];
 

--- a/src/broker.js
+++ b/src/broker.js
@@ -59,7 +59,12 @@ let cli = function (argv) {
 
 		log.d(`Broker serve:\n${JSON.stringify(xgraphArgv, null, 2)}`);
 
-		await xgraph.execute(xgraphArgv);
+		try{
+			let system = await xgraph.execute(xgraphArgv);
+			system.on('exit', (evt) => {
+				log.i('system finished code', evt.exitCode);
+			});
+		} catch (e) {log.e(e)}
 	}
 
 	function add() {
@@ -81,12 +86,14 @@ let cli = function (argv) {
 
 			log.d(`Broker add:\n${JSON.stringify(xgraphArgv, null, 2)}`);
 			
-			let system = await xgraph.execute(xgraphArgv);
-			system.on('exit', (evt) => {
-				log.i('system finished code', evt.exitCode);
-				cleanUp();
-			});
-
+			
+			try{
+				let system = await xgraph.execute(xgraphArgv);
+				system.on('exit', (evt) => {
+					log.i('system finished code', evt.exitCode);
+					cleanUp();
+				});
+			} catch (e) {log.e(e)}
 
 			async function cleanUp() {
 				try {

--- a/src/broker.js
+++ b/src/broker.js
@@ -77,6 +77,8 @@ let cli = function (argv) {
 			if (xgraphArgv.indexOf('--source') == -1)
 				xgraphArgv.push('--source', 'mb://modulebroker.xgraphdev.com');
 
+			log.d(`Broker add ${JSON.stringify(xgraphArr, null, 2)}`);
+			
 			let system = await xgraph.execute(xgraphArgv);
 			system.on('exit', (evt) => {
 				log.i('system finished code', evt.exitCode);

--- a/src/broker.js
+++ b/src/broker.js
@@ -57,11 +57,10 @@ let cli = function (argv) {
 		if (xgraphArgv.indexOf('--source') == -1)
 			xgraphArgv.push('--source', 'mb://modulebroker.xgraphdev.com');
 
-		log.d(`Broker serve:\n${JSON.stringify(xgraphArgv, null, 2)}`);
+		log.v(`Broker serve:\n${JSON.stringify(xgraphArgv, null, 2)}`);
 
 		try{
 			let system = await xgraph.execute(xgraphArgv);
-			log.d(typeof system, system);
 		} catch (e) {log.e(e)}
 	}
 
@@ -82,7 +81,7 @@ let cli = function (argv) {
 			if (xgraphArgv.indexOf('--source') == -1)
 				xgraphArgv.push('--source', 'mb://modulebroker.xgraphdev.com');
 
-			log.d(`Broker add:\n${JSON.stringify(xgraphArgv, null, 2)}`);
+			log.v(`Broker add:\n${JSON.stringify(xgraphArgv, null, 2)}`);
 			
 			
 			try{

--- a/src/broker.js
+++ b/src/broker.js
@@ -57,7 +57,7 @@ let cli = function (argv) {
 		if (xgraphArgv.indexOf('--source') == -1)
 			xgraphArgv.push('--source', 'mb://modulebroker.xgraphdev.com');
 
-		log.d(`Broker serve:\n${JSON.stringify(xgraphArr, null, 2)}`);
+		log.d(`Broker serve:\n${JSON.stringify(xgraphArgv, null, 2)}`);
 
 		await xgraph.execute(xgraphArgv);
 	}
@@ -79,7 +79,7 @@ let cli = function (argv) {
 			if (xgraphArgv.indexOf('--source') == -1)
 				xgraphArgv.push('--source', 'mb://modulebroker.xgraphdev.com');
 
-			log.d(`Broker add:\n${JSON.stringify(xgraphArr, null, 2)}`);
+			log.d(`Broker add:\n${JSON.stringify(xgraphArgv, null, 2)}`);
 			
 			let system = await xgraph.execute(xgraphArgv);
 			system.on('exit', (evt) => {

--- a/src/broker.js
+++ b/src/broker.js
@@ -57,6 +57,8 @@ let cli = function (argv) {
 		if (xgraphArgv.indexOf('--source') == -1)
 			xgraphArgv.push('--source', 'mb://modulebroker.xgraphdev.com');
 
+		log.d(`Broker serve:\n${JSON.stringify(xgraphArr, null, 2)}`);
+
 		await xgraph.execute(xgraphArgv);
 	}
 
@@ -77,7 +79,7 @@ let cli = function (argv) {
 			if (xgraphArgv.indexOf('--source') == -1)
 				xgraphArgv.push('--source', 'mb://modulebroker.xgraphdev.com');
 
-			log.d(`Broker add ${JSON.stringify(xgraphArr, null, 2)}`);
+			log.d(`Broker add:\n${JSON.stringify(xgraphArr, null, 2)}`);
 			
 			let system = await xgraph.execute(xgraphArgv);
 			system.on('exit', (evt) => {

--- a/src/broker.js
+++ b/src/broker.js
@@ -61,7 +61,7 @@ let cli = function (argv) {
 
 		try{
 			let system = await xgraph.execute(xgraphArgv);
-			system.on('exit', (evt) => {
+			system.on(‘exit’, (evt) => {
 				log.i('system finished code', evt.exitCode);
 			});
 		} catch (e) {log.e(e)}

--- a/src/broker.js
+++ b/src/broker.js
@@ -61,9 +61,7 @@ let cli = function (argv) {
 
 		try{
 			let system = await xgraph.execute(xgraphArgv);
-			system.on(‘exit’, (evt) => {
-				log.i('system finished code', evt.exitCode);
-			});
+			log.d(typeof system, system);
 		} catch (e) {log.e(e)}
 	}
 


### PR DESCRIPTION
Better logging for broker interaction. Update broker log levels to use the level defined in cli. 

Fixed ‘broker add’ and ‘broker serve’.
Local brokers via broker serve won’t work until we update the master ModuleBroker module from develop and push it to xgraph.modulebroker.net. 